### PR TITLE
Add notes/journaling feature to mood entries

### DIFF
--- a/src/main/java/com/example/moodtracker/model/Mood.java
+++ b/src/main/java/com/example/moodtracker/model/Mood.java
@@ -10,7 +10,7 @@ import java.time.Instant;
 @Entity
 @Data
 @NoArgsConstructor
-@AllArgsConstructor
+// @AllArgsConstructor // Removed to define a custom constructor as per requirements
 public class Mood {
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
@@ -18,10 +18,29 @@ public class Mood {
     private String mood;
     private Instant date;
     private Integer moodRating;
+    @Column(name = "notes", columnDefinition = "TEXT")
+    private String notes;
     @OneToOne(cascade = CascadeType.ALL)
     private Weather weather;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id") // This specifies the foreign key column in the 'mood' table
     private User user;
+
+    public Mood(String mood, Instant date, Integer moodRating, User user, Weather weather, String notes) {
+        this.mood = mood;
+        this.date = date;
+        this.moodRating = moodRating;
+        this.user = user;
+        this.weather = weather;
+        this.notes = notes;
+    }
+
+    public String getNotes() {
+        return notes;
+    }
+
+    public void setNotes(String notes) {
+        this.notes = notes;
+    }
 }

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -18,6 +18,7 @@ CREATE TABLE mood (
     mood VARCHAR(255),
     date TIMESTAMP,
     mood_rating INTEGER,
+    notes TEXT,
     weather_id BIGINT,
     user_id BIGINT,
     CONSTRAINT fk_weather FOREIGN KEY(weather_id) REFERENCES weather(id),

--- a/src/main/resources/templates/moodtracker.html
+++ b/src/main/resources/templates/moodtracker.html
@@ -29,6 +29,10 @@
                 <label for="location">Location:</label>
                 <input type="text" id="location" name="location" value="London" required/>
             </div>
+            <div>
+                <label for="notes">Notes:</label>
+                <textarea id="notes" th:field="*{notes}" rows="3"></textarea>
+            </div>
             <input type="hidden" name="clientCurrentDateTime" id="clientCurrentDateTime"/>
             <!-- Weather related fields can be added here if desired -->
             <button type="submit">Save Mood</button>
@@ -45,6 +49,7 @@
                 Rating: <span th:text="${mood.moodRating}">Rating</span>
                 <!-- Display weather info if available and needed -->
                 <!-- <span th:if="${mood.weather}" th:text="' - Weather: ' + ${mood.weather.description}">Weather</span> -->
+                <p th:if="${mood.notes != null && !mood.notes.isEmpty()}" style="margin-top: 5px; margin-bottom: 0;">Notes: <span th:text="${mood.notes}"></span></p>
             </li>
         </ul>
     </div>

--- a/src/test/java/com/example/moodtracker/controller/MoodControllerTest.java
+++ b/src/test/java/com/example/moodtracker/controller/MoodControllerTest.java
@@ -1,0 +1,105 @@
+package com.example.moodtracker.controller;
+
+import com.example.moodtracker.model.Mood;
+import com.example.moodtracker.model.User;
+import com.example.moodtracker.repository.MoodRepository;
+import com.example.moodtracker.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.ui.Model;
+
+import java.time.Instant;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class MoodControllerTest {
+
+    @Mock
+    private MoodRepository moodRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private Authentication authentication;
+
+    @Mock
+    private SecurityContext securityContext;
+
+    @Mock
+    private Model model; // Added for getMoodsPage, though not the primary focus
+
+    @InjectMocks
+    private MoodController moodController;
+
+    private User testUser;
+    private String testUsername = "testuser";
+
+    @BeforeEach
+    void setUp() {
+        testUser = new User();
+        testUser.setId(1L);
+        testUser.setUsername(testUsername);
+        // Minimal setup for SecurityContext, can be expanded if needed
+        when(authentication.getName()).thenReturn(testUsername);
+        // It's generally better to mock SecurityContextHolder if used directly by the controller
+        // but MoodController takes Authentication as a parameter, which is easier to mock.
+    }
+
+    @Test
+    void testAddMoodWithNotes() {
+        // Arrange
+        Mood moodFormData = new Mood();
+        moodFormData.setMood("Happy");
+        moodFormData.setMoodRating(9);
+        moodFormData.setNotes("Feeling great today, accomplished a lot!");
+
+        when(userRepository.findByUsername(testUsername)).thenReturn(Optional.of(testUser));
+
+        ArgumentCaptor<Mood> moodArgumentCaptor = ArgumentCaptor.forClass(Mood.class);
+
+        // Act
+        String viewName = moodController.addMood(moodFormData, authentication);
+
+        // Assert
+        assertEquals("redirect:/moodtracker", viewName);
+        verify(userRepository, times(1)).findByUsername(testUsername);
+        verify(moodRepository, times(1)).save(moodArgumentCaptor.capture());
+
+        Mood savedMood = moodArgumentCaptor.getValue();
+        assertNotNull(savedMood.getUser());
+        assertEquals(testUsername, savedMood.getUser().getUsername());
+        assertNotNull(savedMood.getDate());
+        assertEquals("Happy", savedMood.getMood());
+        assertEquals(9, savedMood.getMoodRating());
+        assertEquals("Feeling great today, accomplished a lot!", savedMood.getNotes());
+    }
+
+    @Test
+    void testGetMoodsPage() { // Basic test for the GET endpoint
+        // Arrange
+        when(userRepository.findByUsername(testUsername)).thenReturn(Optional.of(testUser));
+        // when(moodRepository.findByUserOrderByDateDesc(testUser)).thenReturn(Collections.emptyList()); // Example
+
+        // Act
+        String viewName = moodController.getMoodsPage(model);
+
+        // Assert
+        assertEquals("moodtracker", viewName);
+        verify(model, times(1)).addAttribute(eq("moods"), anyList());
+        verify(model, times(1)).addAttribute(eq("newMood"), any(Mood.class));
+        verify(model, times(1)).addAttribute(eq("username"), eq(testUsername));
+    }
+}


### PR DESCRIPTION
This commit introduces the ability for you to add free-text notes to your daily mood entries.

Key changes:
- Modified the `mood` table schema to include a `notes` TEXT column.
- Updated the `Mood` entity with a `notes` field, corresponding JPA annotations, constructor, getter, and setter.
- Enhanced the `moodtracker.html` Thymeleaf template:
    - Added a textarea in the mood submission form for `notes`.
    - Updated the mood list to display saved notes, if present.
- Verified that `MoodController` correctly handles the new `notes` field via Spring MVC's automatic data binding.
- Added `MoodControllerTest.java` with unit tests to verify the functionality of adding moods with notes and ensuring notes are saved correctly.